### PR TITLE
Disabling of add button on empty input field of Add Group Members. (#32)

### DIFF
--- a/lib/ui/components/cv_flat_button.dart
+++ b/lib/ui/components/cv_flat_button.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+class CVFlatButton extends StatefulWidget {
+  CVFlatButton({
+    @required Key key,
+    @required this.triggerFunction,
+    @required this.buttonText,
+    this.context,
+  }) : super(key: key);
+  final Function triggerFunction;
+  final String buttonText;
+  final BuildContext context;
+  @override
+  CVFlatButtonState createState() => CVFlatButtonState();
+}
+
+class CVFlatButtonState extends State<CVFlatButton> {
+  Function dynamicFunction;
+  void setDynamicFunction(bool isActive) {
+    setState(() {
+      dynamicFunction = isActive ? widget.triggerFunction : null;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FlatButton(
+      child: Text('${widget.buttonText}'),
+      disabledTextColor: Colors.grey,
+      onPressed: dynamicFunction == null
+          ? null
+          : () => dynamicFunction.call(widget.context),
+    );
+  }
+}

--- a/lib/ui/views/groups/group_details_view.dart
+++ b/lib/ui/views/groups/group_details_view.dart
@@ -14,6 +14,7 @@ import 'package:mobile_app/ui/views/groups/edit_group_view.dart';
 import 'package:mobile_app/ui/views/groups/update_assignment_view.dart';
 import 'package:mobile_app/utils/snackbar_utils.dart';
 import 'package:mobile_app/utils/validators.dart';
+import 'package:mobile_app/ui/components/cv_flat_button.dart';
 import 'package:mobile_app/viewmodels/groups/group_details_viewmodel.dart';
 
 class GroupDetailsView extends StatefulWidget {
@@ -32,6 +33,8 @@ class _GroupDetailsViewState extends State<GroupDetailsView> {
   final _formKey = GlobalKey<FormState>();
   String _emails;
   Group _recievedGroup;
+  final GlobalKey<CVFlatButtonState> addButtonGlobalKey =
+      GlobalKey<CVFlatButtonState>();
 
   @override
   void initState() {
@@ -128,6 +131,7 @@ class _GroupDetailsViewState extends State<GroupDetailsView> {
             _model.errorMessageFor(_model.ADD_GROUP_MEMBERS));
       }
     }
+    setState(() => _emails = null);
   }
 
   void showAddGroupMemberDialog() {
@@ -174,9 +178,11 @@ class _GroupDetailsViewState extends State<GroupDetailsView> {
                   child: Text('CANCEL'),
                   onPressed: () => Navigator.pop(context),
                 ),
-                FlatButton(
-                  child: Text('ADD'),
-                  onPressed: () => onAddGroupMemberPressed(context),
+                CVFlatButton(
+                  key: addButtonGlobalKey,
+                  triggerFunction: onAddGroupMemberPressed,
+                  context: context,
+                  buttonText: 'ADD',
                 ),
               ],
             ),

--- a/lib/ui/views/projects/project_details_view.dart
+++ b/lib/ui/views/projects/project_details_view.dart
@@ -10,6 +10,7 @@ import 'package:mobile_app/models/collaborators.dart';
 import 'package:mobile_app/models/projects.dart';
 import 'package:mobile_app/services/dialog_service.dart';
 import 'package:mobile_app/services/local_storage_service.dart';
+import 'package:mobile_app/ui/components/cv_flat_button.dart';
 import 'package:mobile_app/ui/views/base_view.dart';
 import 'package:mobile_app/ui/views/profile/profile_view.dart';
 import 'package:mobile_app/ui/views/projects/edit_project_view.dart';
@@ -36,6 +37,8 @@ class _ProjectDetailsViewState extends State<ProjectDetailsView> {
   final _formKey = GlobalKey<FormState>();
   String _emails;
   Project _recievedProject;
+  final GlobalKey<CVFlatButtonState> addButtonGlobalKey =
+      GlobalKey<CVFlatButtonState>();
 
   @override
   void initState() {
@@ -305,6 +308,10 @@ class _ProjectDetailsViewState extends State<ProjectDetailsView> {
                 key: _formKey,
                 child: TextFormField(
                   maxLines: 5,
+                  onChanged: (emailValue) {
+                    addButtonGlobalKey.currentState
+                        .setDynamicFunction(emailValue.isNotEmpty);
+                  },
                   autofocus: true,
                   decoration: CVTheme.textFieldDecoration.copyWith(
                     hintText: 'Email Ids',
@@ -321,9 +328,11 @@ class _ProjectDetailsViewState extends State<ProjectDetailsView> {
                   child: Text('CANCEL'),
                   onPressed: () => Navigator.pop(context),
                 ),
-                FlatButton(
-                  child: Text('ADD'),
-                  onPressed: () => onAddCollaboratorsPressed(context),
+                CVFlatButton(
+                  key: addButtonGlobalKey,
+                  triggerFunction: onAddCollaboratorsPressed,
+                  context: context,
+                  buttonText: 'ADD',
                 ),
               ],
             ),
@@ -553,7 +562,6 @@ class _ProjectDetailsViewState extends State<ProjectDetailsView> {
               );
             });
           }
-
           return ListView(
             padding: const EdgeInsets.all(16),
             children: _items,


### PR DESCRIPTION
* Disabled add button on empty input field of Add Group Members.

* Fixed the disabling of Add button when form is closed.

* Fixed Formatting Errors

* Fixed state management issues of AddButton

* Minor Refactoring changes

* Deleted pubspec.lock

* Added pubspec.lock with no changes

* Disabled add button on empty input field of Add Collaborators form

* Minor formatting changes

* Update group_details_view.dart

* Update project_details_view.dart

* Refactor formatting

* Made a separate stateful widget for ADD Button

* Renamed CVStatefulButton to CVFlatButton

* Used absolute path in group_details_view.dart

* Removed errors.

* Rearranged parameters according to conventions

* Trigger Github Actions

Fixes #

Describe the changes you have made in this PR -

Screenshots of the changes (If any) -

Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.
